### PR TITLE
Panic on Bad User Input for -peer Flag

### DIFF
--- a/src/beemesh.go
+++ b/src/beemesh.go
@@ -116,8 +116,11 @@ func init() {
 	// Connect to the bootstrap nodes
 	logger.Debug("Connect boostrap nodes: ", config.BootstrapPeers)
 	for _, multiaddr := range config.BootstrapPeers {
-		addrInfo, _ := peer.AddrInfoFromP2pAddr(multiaddr)
-		go notifee.HandlePeerFound(*addrInfo)
+		if addrInfo, err := peer.AddrInfoFromP2pAddr(multiaddr); err == nil {
+			go notifee.HandlePeerFound(*addrInfo)
+		} else {
+			logger.Panic(err)
+		}
 	}
 	peersChan, err := routingDiscovery.FindPeers(ctx, config.AppID)
 	if err != nil {

--- a/src/flags.go
+++ b/src/flags.go
@@ -11,20 +11,20 @@ import (
 // A new type we need for writing a custom flag parser
 type addrList []maddr.Multiaddr
 
-func (al *addrList) String() string {
-	strs := make([]string, len(*al))
-	for i, addr := range *al {
+func (al addrList) String() string {
+	strs := make([]string, len(al))
+	for i, addr := range al {
 		strs[i] = addr.String()
 	}
 	return strings.Join(strs, ",")
 }
 
-func (al *addrList) Set(value string) error {
+func (al addrList) Set(value string) error {
 	addr, err := maddr.NewMultiaddr(value)
 	if err != nil {
 		return err
 	}
-	*al = append(*al, addr)
+	al = append(al, addr)
 	return nil
 }
 

--- a/src/flags.go
+++ b/src/flags.go
@@ -11,20 +11,20 @@ import (
 // A new type we need for writing a custom flag parser
 type addrList []maddr.Multiaddr
 
-func (al addrList) String() string {
-	strs := make([]string, len(al))
-	for i, addr := range al {
+func (al *addrList) String() string {
+	strs := make([]string, len(*al))
+	for i, addr := range *al {
 		strs[i] = addr.String()
 	}
 	return strings.Join(strs, ",")
 }
 
-func (al addrList) Set(value string) error {
+func (al *addrList) Set(value string) error {
 	addr, err := maddr.NewMultiaddr(value)
 	if err != nil {
 		return err
 	}
-	al = append(al, addr)
+	*al = append(*al, addr)
 	return nil
 }
 


### PR DESCRIPTION
In beemesh.go , handle peer.AddrInfoFromP2pAddr(go-multiaddr.Multiaddr) error error by panicking.